### PR TITLE
Remove HTTPS in links to www.fmi-standard.org

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -44,7 +44,7 @@ sections:
 
     - title: Does my simulation tool support FMI?
       content: >
-        Please see the [FMI tools page](https://fmi-standard.org/tools) for a list of tools for that tool vendors have announced their support of FMI.
+        Please see the [FMI tools page](http://fmi-standard.org/tools) for a list of tools for that tool vendors have announced their support of FMI.
 
 
         **While the FMI project defines cross check rules, the tool vendors carry sole responsibility for their stated FMI support and the provided compatibility results.**
@@ -59,7 +59,7 @@ sections:
 
     - title: Is there a tool vendor independent way to access model information during simulation?
       content: >
-        ASAM XIL-MA is a standardized API that allows the access of model parameters, stimulations and simulation results and to control simulation experiments as well. Please see the related [ASAM XIL-MA section](https://fmi-standard.org/related#standards).
+        ASAM XIL-MA is a standardized API that allows the access of model parameters, stimulations and simulation results and to control simulation experiments as well. Please see the related [ASAM XIL-MA section](http://fmi-standard.org/related#standards).
 
   - title: I'm a developer and want to support FMI with my tool
     articles:
@@ -70,7 +70,7 @@ sections:
 
           + First make a quick pass trough the [standard document](https://svn.modelica.org/fmi/branches/public/specifications/v2.0/FMI_for_ModelExchange_and_CoSimulation_v2.0.pdf).
 
-          + Then browse and play with the [available 3rd party development toolkits](https://fmi-standard.org/downloads#3rdparty).
+          + Then browse and play with the [available 3rd party development toolkits](http://fmi-standard.org/downloads#3rdparty).
 
           + Read the implementation hints contained in [FMI_for_ModelExchange_v1.0.zip](https://svn.modelica.org/fmi/branches/public/specifications/v1.0/FMI_for_ModelExchange_v1.0.zip) - not yet available for FMI 2.0.
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -25,7 +25,7 @@ permalink: /
                 or <a href="https://trac.fmi-standard.org/export/700/branches/public/docs/Modelica2011/The_Functional_Mockup_Interface.ppt" target="_blank">PPT</a> format).
             </p>
             <p>
-                The first version, <a href="https://fmi-standard.org/downloads#version1" target="_blank">FMI 1.0</a>,
+                The first version, <a href="http://fmi-standard.org/downloads#version1" target="_blank">FMI 1.0</a>,
                 was published in 2010, followed by <a href="{{ '/downloads' | prepend: site.baseurl}}" target="_blank">FMI
                 2.0</a>
                 in July 2014. The FMI development was initiated by Daimler AG with


### PR DESCRIPTION
Since HTTPS is no longer supported with the move to GitHub Pages I've removed the https:// links