### PR TITLE
Fix html syntax of FAQ page

### DIFF
--- a/pages/faq/index.html
+++ b/pages/faq/index.html
@@ -38,7 +38,7 @@ layout: default
     </article>
 	
 		<article class="contentbox">
-        <h3 class="title title-two contentbox-title>"Why shall the next FMI release with new features be 3.0 and not 2.1?</h3>
+        <h3 class="title title-two contentbox-title">Why shall the next FMI release with new features be 3.0 and not 2.1?</h3>
         <p class="contentbox-content">
             <p>After intense struggles to build easy to understand FMI Change Proposals (FCPs), the FMI Steering Committee decided that a point was reached where the cost to keep the FMI 2.1 release backward compatible with 2.0 was too high. 
 			Consequently, the decision was reached to rename the next release to "FMI 3.0".</p>


### PR DESCRIPTION
Move quote to correct position. (Heading was not shown. Full paragraph was shown in heading format)