### PR TITLE
Create 2018-10-16-Issue-tracking-for-FMI-Standard-moved-to-Github-iss…

### DIFF
--- a/_posts/2018-10-16-Issue-tracking-for-FMI-Standard-moved-to-Github-issues.md
+++ b/_posts/2018-10-16-Issue-tracking-for-FMI-Standard-moved-to-Github-issues.md
@@ -4,5 +4,5 @@ categories: [news]
 layout: post
 ---
 
-Our issue tracking  has moved from Trac  (https://trac.fmi-standard.org/) to Github issues at https://github.com/modelica/fmi-standard/issues.
+Our issue tracking has moved from Trac (https://trac.fmi-standard.org/) to Github issues at https://github.com/modelica/fmi-standard/issues.
 All issues have been transferred. Please do not edit Trac tickets any more. 

--- a/_posts/2018-10-16-Issue-tracking-for-FMI-Standard-moved-to-Github-issues.md
+++ b/_posts/2018-10-16-Issue-tracking-for-FMI-Standard-moved-to-Github-issues.md
@@ -1,0 +1,8 @@
+---
+title: Issue tracking for FMI Standard moved to Github issues
+categories: [news]
+layout: post
+---
+
+Our issue tracking  has moved from Trac  (https://trac.fmi-standard.org/) to Github issues at https://github.com/modelica/fmi-standard/issues.
+All issues have been transferred. Please do not edit Trac tickets any more. 


### PR DESCRIPTION
News on Github issue tracking