### PR TITLE
adding Fraunhofer IEM as Advisory Committee member

### DIFF
--- a/pages/development.md
+++ b/pages/development.md
@@ -61,7 +61,7 @@ Current Members of the Steering Committee: BOSCH, Dassault Systemes, dSPACE, ESI
 
 The advisory committee contributes to the design of FMI. It consists of organizational members that have no voting rights but access to internal resources.
 
-Current Members of the Advisory Committee: ABB, AVL, DLR, Fraunhofer (IIS/EAS First, SCAI), Open Modelica Consortium, PMSF, TLK Thermo, TWT, University of Halle, Wolfram MathCore AB
+Current Members of the Advisory Committee: ABB, AVL, DLR, Fraunhofer (IEM, IIS/EAS First, SCAI), Open Modelica Consortium, PMSF, TLK Thermo, TWT, University of Halle, Wolfram MathCore AB
 
 ## Project leader
 


### PR DESCRIPTION
Dear FMI-Maintainer!

Please add us (Fraunhofer IEM) to the FMI Advisory Committee please.
Because we tell a many part of our reasons at the fmi meeting in roanne at okt. 2018.10.23/24.
I hope that email and my statements at fmi meeting in roanne are necessary!

Thanks for that.

Best regards