### PR TITLE
Update 20-sim FMU import status to available

### DIFF
--- a/_data/tools.csv
+++ b/_data/tools.csv
@@ -1,5 +1,5 @@
 name,id,homepage,description,license,platforms,export_cs_fmi1,export_cs_fmi2,export_me_fmi1,export_me_fmi2,import_cs_fmi1,import_cs_fmi2,import_me_fmi1,import_me_fmi2
-20-sim,20sim,https://www.20sim.com/,Modeling and simulation program for mechatronic systems and control,commercial,darwin64 linux32 linux64 win32 win64,available,available,,,planned,planned,,
+20-sim,20sim,https://www.20sim.com/,Modeling and simulation program for mechatronic systems and control,commercial,darwin64 linux32 linux64 win32 win64,available,available,,,available,available,,
 20-sim 4C,20sim4C,https://www.20sim4C.com/,Rapid prototyping tool for embedded hardware and industrial controllers,commercial,win64,,,,,planned,planned,planned,planned
 @Source,AtSource,https://podiumtechnology.co.uk/atsource-targets.htm#Modelisar,Simulink via @Source,commercial,win64,,,available,,,,,
 Adams,Adams,https://www.mscsoftware.com/Products/CAE-Tools/Adams.aspx,High end multibody dynamics simulation software from MSC Software,commercial,linux64 win64,available,available,,,available,available,available,available


### PR DESCRIPTION
FMU import for co-simulation FMUs is supported since 20-sim 4.7.0 (2-03-2018), so planned should become available.