### PR TITLE
Add support for Google Analytics

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,23 @@
   <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+
+  <script type="text/javascript" src="//www.PrivacyPolicies.com/cookie-consent/releases/3.0.0/cookie-consent.js"></script>
+  <script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+    cookieconsent.run({"notice_banner_type":"headline","consent_type":"express","palette":"light","change_preferences_selector":"#changePreferences","language":"en","cookies_policy_url":"https://fmi-standard.org/privacy/","website_name":"fmi-standard.org"});
+    });
+  </script>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script type="text/plain" async cookie-consent="tracking" src="https://www.googletagmanager.com/gtag/js?id=UA-XXXXXX"></script>
+  <script type="text/plain" cookie-consent="tracking">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-XXXXXX', { 'anonymize_ip': true });
+  </script>
+
 </head>
 
 <body>
@@ -72,6 +89,9 @@
       </li>
       <li class="nav-item">
         <a class="nav-link" href="{{ "/contact/" | relative_url }}">Contact</a>
+      </li>
+      <li class="nav-item">
+        <a id="changePreferences" class="nav-link"  href="#">Change Tracking Preferences</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
There is a Window popping up before the main content informing the user
that cookies are used and that the preferences may be changed.
The content is viewable without setting this. The only annoying part
is that there is no button to disable all non-essential cookies, and
that the categories for functional cookies and ad cookies cannot be
disabled (we do not use these).

Once preferences have been set, they can be changed through a link at
the foot of the page.

TODO: A Google Analytics account needs to be created and maintained.
  This must not track more than the privacy policy states. The current
  code uses a placeholder XXXX for the Google analytics.
  Note when creating your own GA account for debugging that Chrome/Firefox
  incognito mode blocks GA (Chrome also does it by default if Do Not Track is
  set, and Firefox does it by default and you can only enable GA for the
  current session by clicking).
TODO: The privacy policy must be updated with the new tracking. It
  must state that:
  * cookies are used to collect data
  * the third-party Google Analytics is used to collect and process the data
  * what we do with the collected data (including who it is sent to)

When updating the consent you may need to refresh or click another link
before the tracking starts/stops.