### PR TITLE
Add Google calendar events to start page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -97,11 +97,5 @@
   </div>
 </footer>
 
-<script>
-$(document).ready(function() {
-  $('[data-toggle="popover"]').popover();
-});
-</script>
-
 </body>
 </html>

--- a/_posts/2015-01-18-eight-tool-vendors.md
+++ b/_posts/2015-01-18-eight-tool-vendors.md
@@ -1,6 +1,6 @@
 ---
 title: Eight tool vendors
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2015-02-09-fmi-strategy-meeting.md
+++ b/_posts/2015-02-09-fmi-strategy-meeting.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Strategy Meeting to be held
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2015-09-21-fmi-user-meeting-versailles.md
+++ b/_posts/2015-09-21-fmi-user-meeting-versailles.md
@@ -1,6 +1,6 @@
 ---
 title: FMI User Meeting at the 11th Modelica Conference, Versailles (France)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2015-09-24-fmi-design-meeting-velizy.md
+++ b/_posts/2015-09-24-fmi-design-meeting-velizy.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at Dassault Systemes, Velizy (France)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2015-12-14-fmi-design-meeting-oberpfaffenhofen.md
+++ b/_posts/2015-12-14-fmi-design-meeting-oberpfaffenhofen.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at DLR in Oberpfaffenhofen (Germany)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2016-06-27-fmi-design-meeting-renningen.md
+++ b/_posts/2016-06-27-fmi-design-meeting-renningen.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at Bosch in Renningen (Germany)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2017-05-15-fmi-user-meeting-prague.md
+++ b/_posts/2017-05-15-fmi-user-meeting-prague.md
@@ -1,6 +1,6 @@
 ---
 title: FMI User Meeting at Modelica Conference in Prague (Czech Republic)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2017-05-17-fmi-design-meeting-prague.md
+++ b/_posts/2017-05-17-fmi-design-meeting-prague.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at Modelica Conference 2017 in Prague (Czech Republic)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2017-06-13-fmi-design-meeting-paderborn.md
+++ b/_posts/2017-06-13-fmi-design-meeting-paderborn.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at dSPACE in Paderborn (Germany)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2017-10-18-modelica-strategy-meeting-lund.md
+++ b/_posts/2017-10-18-modelica-strategy-meeting-lund.md
@@ -1,6 +1,6 @@
 ---
 title: Modelica Association Strategy Meeting in Lund (Sweden)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2017-11-28-fmi-design-meeting-munich.md
+++ b/_posts/2017-11-28-fmi-design-meeting-munich.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at ITK in Munich (Germany)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2018-04-04-fmi-design-meeting-dresden.md
+++ b/_posts/2018-04-04-fmi-design-meeting-dresden.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at ESI-ITI in Dresden (Germany)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2018-05-22-fmi-forum-japan.md
+++ b/_posts/2018-05-22-fmi-forum-japan.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Forum 2018 Japan 2018
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2018-09-05-fmi-design-meeting-roanne.md
+++ b/_posts/2018-09-05-fmi-design-meeting-roanne.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at Siemens Industry Software in Roanne (France)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2018-09-06-fmi-at-modelica-conference-americas.md
+++ b/_posts/2018-09-06-fmi-at-modelica-conference-americas.md
@@ -1,6 +1,6 @@
 ---
 title: FMI at the American Modelica Conference 2018
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2019-02-12-fmi-design-meeting-paderborn.md
+++ b/_posts/2019-02-12-fmi-design-meeting-paderborn.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at Fraunhofer IEM in Paderborn (Germany)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2019-03-04-ssp-and-dcp-standards-released.md
+++ b/_posts/2019-03-04-ssp-and-dcp-standards-released.md
@@ -1,12 +1,12 @@
 ---
-title: SSP and DCP companion standards of FMI have been released
+title: SSP and DCP companion standards released
 categories: [news]
 layout: post
 ---
 
-At the Modelica Conference 2019, two new standards complementing the FMI standard have been released: 
+At the Modelica Conference 2019, two new standards complementing the FMI standard have been released:
 
-[System Structure and Parameterization (**SSP**)](https://ssp-standard.org/) is a tool independent standard to define a complete system consisting of one or more FMUs including their parameterization that can be transferred between simulation tools. 
+[System Structure and Parameterization (**SSP**)](https://ssp-standard.org/) is a tool independent standard to define a complete system consisting of one or more FMUs including their parameterization that can be transferred between simulation tools.
 
 [Distributed Co-Simulation Protocol (**DCP**)](https://dcp-standard.org/) is a platform and communication medium independent standard for the integration of models or real-time systems into simulation environments.
 

--- a/_posts/2019-03-04-user-meeting-at-modelica-conference-2019.md
+++ b/_posts/2019-03-04-user-meeting-at-modelica-conference-2019.md
@@ -1,6 +1,6 @@
 ---
 title: FMI User Meeting at the Modelica Conference 2019
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2019-03-06-fmi-design-meeting-after-Modelica-Conference-Regensburg.md
+++ b/_posts/2019-03-06-fmi-design-meeting-after-Modelica-Conference-Regensburg.md
@@ -1,14 +1,14 @@
 ---
 title: FMI Design Meeting after Modelica Conference in Regensburg, Germany
-categories: [news]
+categories: [events]
 layout: post
 ---
-You are invited to join us for the FMI Design Meeting after the Modelica Conference 2019 at OTH Regensburg on March 6th in the 
+You are invited to join us for the FMI Design Meeting after the Modelica Conference 2019 at OTH Regensburg on March 6th in the
 afternoon, 7th (and optionally 8th for working groups) 2019. The rough agenda is the following
 
 * __Wednesday March 6th  16-18: Kick-off__
 ** __Guests are welcome: You are invited to join this Kick-off meeting!
-It will be a discussion to collect feedback and ideas regarding FMI from the conference. 
+It will be a discussion to collect feedback and ideas regarding FMI from the conference.
 (please send an email to christian.bertsch(at)de.bosch.com if you want to participate)__
 * Thursday March 7th: FMI Project members working on FMI 3.0 (active participation requires signing the Corporate Contributor License Agreement, CCLA)
 * Friday March 8th optionally for FMI working groups

--- a/_posts/2019-04-15-FMI-Design-Meeting-Renningen.md
+++ b/_posts/2019-04-15-FMI-Design-Meeting-Renningen.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting at Robert Bosch Research Campus June 25 2019, Renningen (Germany)
-categories: [news]
+categories: [events]
 layout: post
 ---
 

--- a/_posts/2019-06-17-fmi-design-meeting-lund.md
+++ b/_posts/2019-06-17-fmi-design-meeting-lund.md
@@ -1,6 +1,6 @@
 ---
 title: FMI Design Meeting and Jubilee Modelica Symposium in Lund, Sweden
-categories: [news]
+categories: [events]
 layout: post
 ---
 The Modelica Association, Modelica companies in Lund and Lund University are organizing a jubilee symposium in Lund on September 30, 2019, to celebrate the 100th Modelica Design Meeting taking place in Lund on October 1-2, 2019.

--- a/pages/home.html
+++ b/pages/home.html
@@ -58,9 +58,13 @@ layout: default
         with other tools.
     </p>
   </div>
-  <div class="col-lg-6 news">
+  <div id="app" class="col-lg-6 news">
+
     <h2 class="title title-highlighted">News</h2>
-    {% for post in site.posts limit: 16 %}
+
+    {% assign counter = 0 %}
+    {% for post in site.posts limit: 100 %}
+      {% if post.categories contains "news" %}
     <div class="d-flex">
       <div class="flex-shrink">
         <span class="badge badge-light">{{ post.date | date: " %Y-%m-%d" }}</span>
@@ -69,8 +73,32 @@ layout: default
         <a href="{{ post.url }}">{{ post.title }}</a>
       </div>
     </div>
+      {% assign counter=counter | plus:1 %}
+      {% endif %}
+      {% if counter >= 5 %}
+        {% break %}
+      {% endif %}
     {% endfor %}
     <a href="{{ "/news/" | relative_url }}" class="more-link">more...</a>
+
+    <h2 class="title title-highlighted">Events</h2>
+
+    {% raw %}
+    <div v-for="item in items" class="d-flex">
+      <div class="flex-shrink">
+        <span class="badge badge-light">{{ item.start.dateTime.substring(0,10) }}</span>
+      </div>
+      <div>
+        <a v-bind:href="item.htmlLink">{{ item.summary }}</a> <a href="#" data-toggle="tooltip" data-original-title="Teleconference"><i v-if="!item.location" class="fas fa-phone ml-1"></i></a>
+        <a v-if="item.location" v-bind:href="'https://maps.google.com/?q=' + encodeURIComponent(item.location)"><i data-toggle="tooltip" title="" v-bind:data-original-title="item.location" class="fas fa-map-marker-alt ml-1"></i></a>
+      </div>
+    </div>
+    <div class="mt-3">
+      <a class="btn btn-outline-primary btn-sm mr-2" href="https://calendar.google.com/calendar/ical/obe72dhd3apjmipcpmr2asehjs%40group.calendar.google.com/public/basic.ics"><i class="far fa-calendar-alt mr-2"></i>iCal Calendar</a>
+      <a class="btn btn-outline-primary btn-sm mr-2" href="https://calendar.google.com/calendar/embed?src=obe72dhd3apjmipcpmr2asehjs%40group.calendar.google.com&ctz=Europe%2FBerlin"><i class="fab fa-google mr-2"></i>Google Calendar</a>
+    </div>
+    {% endraw %}
+
   </div>
 </div>
 
@@ -99,3 +127,32 @@ layout: default
     <footer class="blockquote-footer">Edo Drenth, VP Global Vehicle Dynamics, <a href="https://www.haldex.com">Haldex</a></footer>
   </div>
 </div>
+
+<!-- Vue.js -->
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
+<script>
+  new Vue({
+    el: '#app',
+    data () {
+      return {
+        items: null
+      }
+    },
+    mounted () {
+      axios
+        .get('https://www.googleapis.com/calendar/v3/calendars/obe72dhd3apjmipcpmr2asehjs@group.calendar.google.com/events?key=AIzaSyDo78g40_od26-CDjAs6qM21f34deK-GyU')
+        .then(response => (this.items = response.data.items.sort(
+          (a,b) => new Date(b.start.dateTime) - new Date(a.start.dateTime)))
+        )
+        .finally(() => (
+            /* enable popovers and tooltips */
+            $(document).ready(function() {
+              $('[data-toggle="popover"]').popover();
+              $('[data-toggle="tooltip"]').tooltip();
+            })
+          )
+        )
+    }
+  })
+</script>

--- a/pages/news.html
+++ b/pages/news.html
@@ -7,6 +7,7 @@ layout: default
 <div class="news">
   <h2 class="title title-highlighted">News</h2>
   {% for post in site.posts %}
+    {% if post.categories contains "news" %}
   <div class="d-flex">
     <div class="flex-shrink">
       <span class="badge badge-light">{{ post.date | date: " %Y-%m-%d" }}</span>
@@ -15,5 +16,6 @@ layout: default
       <a href="{{ post.url }}">{{ post.title }}</a>
     </div>
   </div>
+    {% endif %}
   {% endfor %}
 </div>

--- a/pages/tools.html
+++ b/pages/tools.html
@@ -237,3 +237,11 @@ filterRows();
 <script>
 $("#tbl-results").stickyTableHeaders({fixedOffset: 60});
 </script>
+
+<script>
+/* enable popovers and tooltips */
+$(document).ready(function() {
+  $('[data-toggle="popover"]').popover();
+  $('[data-toggle="tooltip"]').tooltip()
+});
+</script>


### PR DESCRIPTION
- add post category "events" and hide event posts
- shorten post title that breaks layout
- remove popover script from default.html
