### PR TITLE
Add AVL to steering committe member list

### DIFF
--- a/pages/development.md
+++ b/pages/development.md
@@ -55,7 +55,7 @@ Membership in this project is open to companies, institutes, universities and ot
 
 The steering committee defines FMI policy, strategy, feature roadmap, and future FMI releases. Members are organizations that actively support FMI. Especially, a member has either to provide the FMI standard or part of it in a commercial or open source tool, and/or actively use FMI in industrial projects.
 
-Current Members of the Steering Committee: BOSCH, Dassault Systemes, dSPACE, ESI ITI, IFP EN, Maplesoft, Modelon, QTronic, Siemens PLM
+Current Members of the Steering Committee: AVL, BOSCH, Dassault Systemes, dSPACE, ESI ITI, IFP EN, Maplesoft, Modelon, QTronic, Siemens PLM
 
 ## Advisory Committee
 


### PR DESCRIPTION
@klausschuch: is this fine listing AVL in that way (and not AVL List GmbH)? 
E.g., for Bosch we also list it as Bosch and not as "Robert Bosch GmbH" ...