### PR TITLE
Reflect change from QTronic to Synopsys

### DIFF
--- a/pages/development.md
+++ b/pages/development.md
@@ -55,7 +55,7 @@ Membership in this project is open to companies, institutes, universities and ot
 
 The steering committee defines FMI policy, strategy, feature roadmap, and future FMI releases. Members are organizations that actively support FMI. Especially, a member has either to provide the FMI standard or part of it in a commercial or open source tool, and/or actively use FMI in industrial projects.
 
-Current Members of the Steering Committee: AVL List, BOSCH, Dassault Systemes, dSPACE, ESI ITI, IFP EN, Maplesoft, Modelon, QTronic, Siemens PLM
+Current Members of the Steering Committee: AVL List, BOSCH, Dassault Systemes, dSPACE, ESI ITI, IFP EN, Maplesoft, Modelon, Siemens PLM, Synopsys
 
 ## Advisory Committee
 
@@ -67,7 +67,7 @@ Current Members of the Advisory Committee: ABB, Altair, DLR, ETAS, Fraunhofer (I
 
 The project leader and the deputy is elected by the Steering Committee for a two-years period
 
-Current Project Leader: Andreas Junghanns projectleader@fmi-standard.org from QTronic GmbH, deputy Torsten Blochwitz from ESI ITI GmbH
+Current Project Leader: Andreas Junghanns projectleader@fmi-standard.org from Synopsys GmbH, deputy Torsten Blochwitz from ESI ITI GmbH
 
 ## Visitors
 
@@ -76,5 +76,3 @@ The FMI meetings are open to the public. Participants that are neither in the St
 ## Voting
 
 Voting is performed by the Steering Committee members according to paragraph 14 of the [Modelica Association Bylaws](https://www.modelica.org/legal/organizational/Modelica-bylaws-2012-02-29.pdf/at_download/file) but with a quorum of four organizations. More information can be found in the [FMI project Bylaws](/assets/FMI_ProjectRules_v2.0_2016_06_21.pdf).
-
-

--- a/pages/history.md
+++ b/pages/history.md
@@ -37,13 +37,13 @@ The FMI specifications are published under the CC-BY-SA (Creative Common Attribu
 Torsten Blochwitz from ITI
 
 **Current Project Leader**  
-Andreas Junghanns projectleader@fmi-standard.org from QTronic GmbH
+Andreas Junghanns projectleader@fmi-standard.org from Synopsys GmbH
 
 **Initial members of the Steering Committee**  
 Daimler, Dassault Systèmes, IFP EN, ITI, LMS, Modelon, QTronic, SIMPACK
 
 **Current Members of the Steering Committee**  
-AVL List, BOSCH, Dassault Systemes, dSPACE, ESI ITI, IFP EN, Maplesoft, Modelon, QTronic, Siemens PLM
+AVL List, BOSCH, Dassault Systemes, dSPACE, ESI ITI, IFP EN, Maplesoft, Modelon, Siemens PLM, Synopsys
 
 **Initial members of the Advisory Committee**  
 Armines, DLR, Fraunhofer (IIS/EAS First, SCAI), Open Source Modelica Consortium, TWT, University of Halle


### PR DESCRIPTION
This changes QTronic into Synopsys according to the FMI Steering Committee meeting decition Dec 16, 1019