### PR TITLE
Add pandapower-fmu tool

### DIFF
--- a/_data/tools.csv
+++ b/_data/tools.csv
@@ -109,6 +109,7 @@ OpenModelica,OpenModelica,https://openmodelica.org,Open source Modelica environm
 OPTIMICA Compiler Toolkit,OPTIMICA_Studio,https://www.modelon.com/products-services/modelon-creator-suite/optimica-compiler-toolkit/,"Modelica-based mathematical engine that offers solution for the automation, simulation and optimization of system behaviors throughout the model-based design cycle",commercial,win32 win64,available,available,available,available,available,available,available,available
 optiSLang,optiSLang,https://www.dynardo.de/en/software/optislang.html,optiSLang supports the export of Metamodels of optimal Prognosis (MOP) as FMU,commercial,win64,,,available,planned,,,planned,planned
 Overture,Overture,https://overturetool.org/,Modelling tool for the Vienna Development Method with supports for export of tool wrapper and source code FMUs,commercial,darwin64 linux32 linux64 win32 win64,available,,,,,,,
+pandapower-fmu,pandapower-fmu,https://framagit.org/Adrien.Gougeon/pandapower-fmu,open source tool for power system modeling,osi,linux64,,available,,,,,,
 PLECS,PLECS,https://www.plexim.com,Simulation platform for power electronic systems,commercial,darwin64 win64 linux64,,,,,,,,available
 PragmaDev Studio,PragmaDev_Studio,http://www.pragmadev.com/,Modeling and testing tools for communicating systems,commercial,darwin64 linux64 win32,,,,,,available,,available
 PROOSIS,PROOSIS,https://www.ecosimpro.com/products/proosis/,"PROOSIS, Propulsion Object-Oriented Simulation Software",commercial,win32 win64,,available,,planned,,available,,planned


### PR DESCRIPTION
pandapower-fmu tool was removed due to a misleading name and link (https://github.com/modelica/fmi-standard.org/pull/234) , this is now fixed