### PR TITLE
Fix list of supported platforms for System Modeler

### DIFF
--- a/_data/tools.csv
+++ b/_data/tools.csv
@@ -150,7 +150,7 @@ SIMULIA Simpack,SIMPACK,https://www.3ds.com/products-services/simulia/products/s
 Simulix,simulix,https://github.com/kvixen/Simulix,FMU builder for Simulink models (based on Simulink Coder),osi,c-code linux32 linux64 win32 win64,,available,,planned,,,,
 Squish GUI Tester,Squish,https://squish.froglogic.com,"Squish is a GUI Test Automation Tool. As an FMU importer, Squish test scripts can access all variables exposed by a FMU and is responsible for driving the simulation process",commercial,win64,,,,,,available,,
 Sulca,Sulca,https://www.simantics.org/demonstration/sulca,"SULCA software is a tool for Ecodesign and for performing Life Cycle Assessments (LCA).",commercial,win64,available,,,,,,,
-SystemModeler,SystemModeler,https://www.wolfram.com/system-modeler,Modelica environment from Wolfram Research,commercial,win32 win64,planned,planned,available,available,planned,planned,available,available
+SystemModeler,SystemModeler,https://www.wolfram.com/system-modeler,Modelica environment from Wolfram Research,commercial,linux32 linux64 win32 win64 darwin64,planned,planned,available,available,planned,planned,available,available
 TAITherm,TAITherm,https://www.thermoanalytics.com/taitherm,"3D Thermal Simulation Software that can be coupled with CFD, FEA, and 1D tools",commercial,linux64 win64,,available,,,available,available,,
 Test-FMUs,Test-FMUs,https://github.com/CATIA-Systems/Test-FMUs,"A set of open source FMUs for prototyping, testing and debugging provided by Dassault Systèmes",osi,c-code darwin64 linux64 win64,available,available,available,available,,,,
 TLK Energy Apps,tlk-energy-apps,https://apps.tlk-energy.de,"Plattform to build web-based simulation apps",commercial,linux64 win64,,,,,,available,,


### PR DESCRIPTION
The list of supported platforms for System Modeler is wrong, it has always supported linux32, linux64, win32, win64, darwin64 so I don't know how it ended up like this. Anyway, this fixes that.