### PR TITLE
Changed VDMCheck license to "osi" not "GPL"

### DIFF
--- a/assets/tools.json
+++ b/assets/tools.json
@@ -3671,7 +3671,7 @@
     },
     {
         "name": "VDMCheck",
-        "license": "GPL",
+        "license": "osi",
         "url": "https://github.com/INTO-CPS-Association/FMI-VDM-Model/releases",
         "vendor": "Aarhus University",
         "logo": "aarhus.png",


### PR DESCRIPTION
Just noticed that "GPL" isn't considered open source. License must be "osi" or "commercial".