### PR TITLE
Fix for description of ETAS VECU-BUILDER

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1362,7 +1362,7 @@
         "logo": "ETAS.svg",
         "vendor": "ETAS",
         "vendorURL": "https://www.etas.com",
-        "description": "ETAS VECU-BUILDER is a tool to generate stand-alone runnable virtual ECUs for verification and validation of automotive microcontroller software in Software-in-Loop (SiL) setups. Input sources may be AUTOSAR-compliant source codes, non-AUTOSAR-compliant source code and even PC binaries.",
+        "description": "ETAS VECU-BUILDER is a tool to generate stand-alone runnable virtual ECUs for verification and validation of automotive microcontroller software in Software-in-the-Loop (SiL) setups. Input sources may be AUTOSAR-compliant source codes, non-AUTOSAR-compliant source code and even PC binaries.",
         "features": [],
         "platforms": ["Windows", "Linux"],
         "fmiVersions": [


### PR DESCRIPTION
Fixed the Description of the ETAS VECU-BUILDER
Software-in-the-Loop instead of Software-in-Loop