### PR TITLE
Fair ordering of the tools list.

### DIFF
--- a/content/tools.html
+++ b/content/tools.html
@@ -141,7 +141,7 @@ title: Tools
     created() {
       axios.get('/assets/tools.json')
         .then(response => {
-          this.tools = response.data
+          this.tools = response.data.sort(function (a, b) { return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1; })
         })
         .catch(error => {
           console.log(error)


### PR DESCRIPTION
The order of the tools should not be the order from the tools.json file. A fair ordering is a alphanumeric sorted tools list by tool name.