### PR TITLE
Add CasADi

### DIFF
--- a/static/assets/images/logos/casadi_logo.svg
+++ b/static/assets/images/logos/casadi_logo.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="825.3584"
+   height="187.99933"
+   id="svg6143"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="logo_2017_horizontal.svg">
+  <defs
+     id="defs6145" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.59524164"
+     inkscape:cx="426.62915"
+     inkscape:cy="254.93691"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4308"
+       originx="-12.996489"
+       originy="-69.090696" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6148">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(60.62349,-428.57089)">
+    <g
+       id="g4899">
+      <path
+         id="rect4299-1-4-6-6-0-5-4-0-5-4-4-8-7-3-6-0-5-6-9-2-1-6-7-6-0-4-1-4-8"
+         transform="translate(-73.619979,427.20065)"
+         d="m 102.69336,107.79297 a 20.367931,20.367931 0 0 1 -2.41797,1.8418 l -0.0879,0.18359 14.08594,48.37305 a 20.367931,20.367931 0 0 1 9.53125,-2.37891 20.367931,20.367931 0 0 1 6.04297,0.93945 l -27.1543,-48.95898 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:161.28417969px;line-height:125%;font-family:Roboto;-inkscape-font-specification:Roboto;letter-spacing:0px;word-spacing:0px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect4299-7-8-1-3-0-9-6-7-16-6-6-5-6-1-5-4-4-5-4-3-5-7-0-5-7-4-4-3"
+         transform="translate(-73.619979,427.20065)"
+         d="m 174.03516,24.673828 a 20.367931,20.367931 0 0 1 -2.54883,3.195313 c 1.04799,0.632221 2.00097,1.280922 2.61133,2.023437 19.58783,14.4307 39.36964,30.155976 51.92968,51.035156 7.72248,12.62084 9.44685,29.543326 -0.33203,41.683596 -15.92838,19.69486 -41.89196,27.79193 -65.77734,34.24609 -5.49217,1.7341 -15.01454,3.00071 -22.25977,4.68555 a 20.367931,20.367931 0 0 1 6.56055,14.94922 20.367931,20.367931 0 0 1 -0.97461,6.15039 c 4.86705,-1.00178 10.04965,-2.65365 12.08984,-2.70899 27.53968,-7.45471 56.56226,-17.77448 75.32227,-39.82031 12.22922,-14.03568 13.35528,-34.61213 5.20313,-50.802733 C 222.65927,62.166168 198.44995,42.325428 174.03516,24.673828 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:161.28417969px;line-height:125%;font-family:Roboto;-inkscape-font-specification:Roboto;letter-spacing:0px;word-spacing:0px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <circle
+         inkscape:transform-center-y="3.4978006"
+         inkscape:transform-center-x="0.87445015"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a20000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         r="13.22885"
+         cy="441.79974"
+         cx="21.181726"
+         id="path3360-3" />
+      <path
+         id="rect4299-7-8-1-3-0-9-6-0"
+         transform="translate(-73.619979,427.20065)"
+         d="M 76.097656,22.650391 C 66.081706,30.164107 56.795976,38.769765 47.744141,47.304688 30.873924,64.717607 14.122594,85.664832 13.03125,110.40234 c -0.148066,3.64279 0.180902,7.18183 0.910156,10.60352 a 20.367931,20.367931 0 0 1 10.601563,-4.66797 c -3.758807,-9.03593 -4.090034,-19.336502 -0.351563,-28.499999 8.57478,-22.62964 27.955673,-39.543358 46.123047,-55.179688 2.308759,-2.300025 5.204477,-4.189914 7.984375,-6.152344 A 20.367931,20.367931 0 0 1 76.097656,22.650391 Z M 47.183594,140.08398 a 20.367931,20.367931 0 0 1 -10.582032,14.45704 c 4.100964,3.30222 8.489666,6.23949 12.966797,8.75586 17.12348,9.91845 36.135767,16.64853 55.580081,20.99218 0.007,-0.002 0.011,-0.006 0.0176,-0.008 a 20.367931,20.367931 0 0 1 -1.43555,-7.45898 20.367931,20.367931 0 0 1 6.05859,-14.46875 C 88.096888,158.0854 65.712514,151.99609 47.183594,140.08398 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:161.28417969px;line-height:125%;font-family:Roboto;-inkscape-font-specification:Roboto;letter-spacing:0px;word-spacing:0px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <circle
+         inkscape:transform-center-y="3.4978006"
+         inkscape:transform-center-x="0.87445015"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a20000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         r="13.22885"
+         cy="519.76947"
+         cx="15.570672"
+         id="path3360-3-3" />
+      <circle
+         inkscape:transform-center-y="3.4978006"
+         inkscape:transform-center-x="0.87445015"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a20000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         r="13.22885"
+         cy="563.67529"
+         cx="-46.638233"
+         id="path3360-3-6" />
+      <circle
+         inkscape:transform-center-y="3.4978006"
+         inkscape:transform-center-x="0.87445015"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a20000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         r="13.22885"
+         cy="603.34137"
+         cx="50.69928"
+         id="path3360-3-6-7" />
+      <path
+         id="rect4299-1-4-6-6-0-5-4-0-5-4-4-8-7-3-6-0-5-6-9-2-1-6-7-6-0-4-1-4-8-9"
+         transform="translate(-73.619979,427.20065)"
+         d="m 70.623047,100.9043 -33.263672,18.63867 c 3.436851,1.98852 6.217531,4.93824 8,8.48633 l 27.330078,-23.55078 a 20.367931,20.367931 0 0 1 -2.066406,-3.57422 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:161.28417969px;line-height:125%;font-family:Roboto;-inkscape-font-specification:Roboto;letter-spacing:0px;word-spacing:0px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect4299-1-4-6-6-0-5-4-0-5-4-4-8-7-3-6-0-5-6-9-2-1-6-7-6-0-4-1-4-8-1"
+         transform="translate(-73.619979,427.20065)"
+         d="M 88.144531,33.824219 78.46875,75.279297 a 20.367931,20.367931 0 0 1 10.722656,-3.080078 20.367931,20.367931 0 0 1 4.089844,0.4375 l 0.04883,-37.72461 a 20.367931,20.367931 0 0 1 -5.185547,-1.08789 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:161.28417969px;line-height:125%;font-family:Roboto;-inkscape-font-specification:Roboto;letter-spacing:0px;word-spacing:0px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect4299-1-4-6-6-0-5-4-0-5-4-4-8-7-3-6-0-5-6-9-2-1-6-7-6-0-4-1-4-8-2"
+         transform="translate(-73.619979,427.20065)"
+         d="M 141.68555,27.128906 98.085938,74.261719 c 4.440512,2.153304 7.948182,5.845598 9.871092,10.390625 l 36.63086,-54.824219 a 20.367931,20.367931 0 0 1 -2.90234,-2.699219 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:161.28417969px;line-height:125%;font-family:Roboto;-inkscape-font-specification:Roboto;letter-spacing:0px;word-spacing:0px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <circle
+         inkscape:transform-center-y="3.4978006"
+         inkscape:transform-center-x="0.87445015"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a20000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         r="13.22885"
+         cy="442.6907"
+         cx="83.747734"
+         id="path3360-3-5" />
+    </g>
+    <g
+       id="g4895"
+       transform="matrix(2.3718669,0,0,2.3718669,371.06772,-1039.3047)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4654-9"
+         d="m 155.47494,634.73007 0,4.32296 0,4.32296 5.24931,0 5.24931,0 0,-4.32296 0,-4.32296 -5.24931,0 -5.24931,0 z m -199.550895,0.74421 c -7.111441,-0.0517 -13.980859,2.29656 -18.274879,6.68105 -5.683451,5.80319 -7.724371,14.8007 -5.396461,23.78714 2.03101,7.84029 7.486513,13.12703 15.875778,15.38606 5.763641,1.55201 12.451303,1.08509 18.834548,-1.31474 l 2.624654,-0.98665 0,-4.54732 c 0,-2.50131 -0.105215,-4.54851 -0.234002,-4.54851 -0.128781,0 -1.827321,0.72982 -3.774147,1.62111 -4.21722,1.93071 -10.220033,2.58055 -13.58403,1.47034 -3.65232,-1.20538 -6.95516,-4.58282 -8.033176,-8.2129 -2.69888,-9.08811 0.766658,-17.80299 8.033176,-20.20116 3.363997,-1.11021 9.36681,-0.46037 13.58403,1.47034 1.946826,0.89129 3.645366,1.61991 3.774147,1.61991 0.128787,0 0.234002,-2.04173 0.234002,-4.53767 l 0,-4.53765 -2.624654,-1.04094 c -3.523175,-1.39634 -7.313947,-2.08131 -11.038986,-2.10841 z m 36.8826619,11.12221 c -2.413292,-0.0248 -4.8992029,0.11756 -7.1309559,0.44388 -7.145487,1.04481 -6.824582,0.7893 -6.824582,5.423 0,3.35747 0.155306,3.95458 0.949267,3.64991 4.27059,-1.63878 8.305152,-2.34363 12.1691799,-2.1253 3.801993,0.21483 4.4997,0.45032 5.792086,1.95281 0.808202,0.93959 1.469133,2.24894 1.469133,2.90932 0,1.09815 -0.463088,1.20015 -5.427821,1.20015 -6.0097719,0 -11.7289799,1.23409 -14.3391019,3.09265 -1.979138,1.40927 -3.700571,5.27108 -3.700571,8.30457 0,4.3552 2.253645,7.71613 6.484439,9.66876 4.703306,2.17072 10.6147369,1.21957 14.5574179,-2.3424 l 2.425637,-2.19284 0,2.23384 0,2.23265 5.558091,0 5.5580911,0 0,-11.31279 c 0,-15.62398 -1.1959031,-19.04189 -7.5977491,-21.71611 -2.101021,-0.87766 -5.920417,-1.38075 -9.942561,-1.4221 z m 39.7244231,0.002 c -2.199065,10e-4 -4.223322,0.148 -5.701626,0.45594 -6.249931,1.30191 -9.577763,5.60362 -8.91128,11.51664 0.616738,5.47169 3.670396,7.6559 12.926661,9.249 3.162239,0.54426 6.110238,1.28825 6.551989,1.65247 1.263131,1.04147 0.620418,3.72599 -1.1121,4.64622 -2.178519,1.15713 -10.563701,0.60173 -14.667184,-0.97218 l -3.24222,-1.24358 0,4.20717 0,4.20717 4.477351,0.73938 c 2.462543,0.40658 4.755256,0.8445 5.094917,0.9734 0.339661,0.12892 3.122831,0.14236 6.184098,0.029 6.571788,-0.24349 10.508831,-1.70668 12.637178,-4.69567 1.906759,-2.6778 2.301556,-6.73459 0.990279,-10.16812 -1.544692,-4.04471 -4.028832,-5.29872 -13.549057,-6.83906 -3.009582,-0.48694 -5.871857,-1.21703 -6.360197,-1.62231 -1.288878,-1.06968 -0.761533,-3.16228 1.024047,-4.06242 2.838881,-1.43113 7.29182,-1.03383 15.902315,1.42088 1.339068,0.38174 1.389523,0.25103 1.389523,-3.61614 l 0,-4.01297 -2.896043,-0.72974 c -2.92229,-0.73584 -7.073535,-1.13731 -10.738651,-1.13502 z m 122.94381,1.10004 0,16.98306 0,16.98305 5.24931,0 5.24931,0 0,-16.98305 0,-16.98306 -5.24931,0 -5.24931,0 z m -156.2441051,18.3967 0,1.64041 c 0,2.40761 -1.618763,5.13135 -3.68489,6.19978 -2.706896,1.39979 -5.388588,1.18269 -7.1502489,-0.57897 -1.819818,-1.81982 -1.920963,-3.40592 -0.341353,-5.35665 1.022664,-1.26294 1.821651,-1.48008 6.1756559,-1.6778 l 5.000836,-0.22677 z"
+         style="fill:#000000" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4654-2"
+         d="m 106.7832,636.37297 0,22.6497 0,22.6485 12.81449,-0.23762 c 11.47489,-0.21369 13.17988,-0.38309 16.30276,-1.6187 4.66021,-1.84385 8.71331,-5.52875 10.83635,-9.8521 1.6066,-3.27167 1.73208,-4.06975 1.73208,-10.94008 0,-6.87032 -0.12548,-7.6684 -1.73208,-10.94007 -2.12304,-4.32335 -6.17614,-8.00826 -10.83635,-9.85211 -3.12288,-1.2356 -4.82787,-1.405 -16.30276,-1.61869 l -12.81449,-0.23883 z m -21.923576,0.10132 -7.308266,0.15801 -7.30947,0.15801 -7.964423,21.5581 c -4.380961,11.85697 -8.127728,22.06996 -8.326282,22.69554 -0.334251,1.05313 0.09624,1.13743 5.819836,1.13743 l 6.181684,0 1.393142,-4.32295 1.391937,-4.32296 8.797896,0 8.796691,0 1.393142,4.32296 1.391937,4.32295 6.126202,0 c 6.04285,0 6.12037,-0.0186 5.76314,-1.38469 -0.19918,-0.76167 -3.912963,-11.0459 -8.253906,-22.85355 l -7.89326,-21.46885 z m 33.657326,8.53133 3.85979,0.41251 c 10.34007,1.10352 14.04961,4.69552 14.04961,13.60454 0,6.84948 -2.57166,10.86409 -8.02835,12.53224 -1.18881,0.36343 -3.89838,0.84574 -6.02126,1.0723 l -3.85979,0.41131 0,-14.01585 0,-14.01705 z m -40.712291,4.29039 c 0.229215,0.25454 1.447351,3.52013 2.706673,7.2564 1.259315,3.73627 2.428181,7.1406 2.598117,7.56518 0.233582,0.58359 -1.059243,0.77196 -5.299967,0.77196 -3.085253,0 -5.614048,-0.20843 -5.619607,-0.46318 -0.02847,-1.28513 5.25688,-15.52781 5.614784,-15.13036 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a20000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.82826948;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -3876,6 +3876,7 @@
         "name": "CasADi",
         "license": "osi",
         "url": "https://casadi.org",
+        "logo": "casadi_logo.svg",
         "vendor": "CasADi",
         "vendorURL": "https://casadi.org",
         "description": "CasADi is an open-source framework for numerical optimization and algorithmic differentiation for C++, Python, MATLAB and Octave.",

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -3871,5 +3871,29 @@
             "CS"
         ],
         "fmuImport": []
+    },
+    {
+        "name": "CasADi",
+        "license": "osi",
+        "url": "https://casadi.org",
+        "vendor": "CasADi",
+        "vendorURL": "https://casadi.org",
+        "description": "CasADi is an open-source framework for numerical optimization and algorithmic differentiation for C++, Python, MATLAB and Octave.",
+        "features": [],
+        "platforms": [
+	    "macOS",
+            "Linux",
+            "Windows"
+        ],
+        "fmiVersions": [
+            "2.0",
+            "3.0"
+        ],
+        "fmuExport": [
+            "ME"
+        ],
+        "fmuImport": [
+            "ME"
+        ]
     }
 ]


### PR DESCRIPTION
Added CasADi to the list of FMI tools. Note that the FMI export is currently FMI 3.0 only whereas FMI import is FMI 2.0 only.