### PR TITLE
Added support for FMI 3.0 in Amesim

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -2991,9 +2991,14 @@
             "Linux",
             "Windows"
         ],
+        "interfaces": [
+            "GUI",
+            "CLI"
+        ],
         "fmiVersions": [
             "1.0",
-            "2.0"
+            "2.0",
+            "3.0"
         ],
         "fmuExport": [
             "CS",


### PR DESCRIPTION
Added support of FMI 3.0 (co-simulation export). Amesim 2304 has been released on Friday, April 28, 2023. 