### PR TITLE
Update supported FMI Versions of ECU-TEST in tools.json

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1244,7 +1244,9 @@
             "Windows"
         ],
         "fmiVersions": [
-            "2.0"
+            "1.0",
+            "2.0",
+            "3.0"
         ],
         "fmuExport": [],
         "fmuImport": [


### PR DESCRIPTION
ECU-TEST supports the versions FMI 1.0, 2.0 and 3.0, because it uses internally the library FMPy