### PR TITLE
Update tools.json

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1621,7 +1621,7 @@
     {
         "name": "FMI Toolbox for MATLAB/Simulink",
         "license": "commercial",
-        "url": "https://www.modelon.com/products-services/modelon-deployment-suite/fmi-toolbox/",
+        "url": "https://modelon.com/fmi-toolbox/",
         "logo": "Modelon.svg",
         "vendor": "Modelon",
         "vendorURL": "https://www.modelon.com/",


### PR DESCRIPTION
Modelon website is updated. https://modelon.com/fmi-toolbox/ is the new URL for FMI Toolbox for MATLAB/Simulink