### PR TITLE
Add SIL Kit FMU Importer to tools.json

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -4154,5 +4154,28 @@
             "CS"
         ],
         "fmuImport": []    
+    },
+    {
+        "name": "SIL Kit FMU Importer",
+        "license": "osi",
+        "url": https://github.com/vectorgrp/sil-kit-fmu-importer/,
+        "vendor": "Vector",
+        "vendorURL": https://www.vector.com/,
+        "description": "SIL Kit FMU Importer allows FMUs to join Vector SIL Kit simulations by synchronizing state, time, and data of an FMU with other SIL Kit participants. It allows cross-platform communication and communication between FMI 2.0 and FMI 3.0 FMUs (if their data types match).",
+        "features": [],
+        "platforms": [
+            "Linux",
+            "Windows"
+        ],
+        "interfaces": [
+            "CLI"
+        ],
+        "fmiVersions": [
+            "2.0",
+            "3.0"
+        ],
+        "fmuImport": [
+            "CS"
+        ]
     }
 ]

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -4158,9 +4158,9 @@
     {
         "name": "SIL Kit FMU Importer",
         "license": "osi",
-        "url": https://github.com/vectorgrp/sil-kit-fmu-importer/,
+        "url": "https://github.com/vectorgrp/sil-kit-fmu-importer/",
         "vendor": "Vector",
-        "vendorURL": https://www.vector.com/,
+        "vendorURL": "https://www.vector.com/",
         "description": "SIL Kit FMU Importer allows FMUs to join Vector SIL Kit simulations by synchronizing state, time, and data of an FMU with other SIL Kit participants. It allows cross-platform communication and communication between FMI 2.0 and FMI 3.0 FMUs (if their data types match).",
         "features": [],
         "platforms": [


### PR DESCRIPTION
We internally tested the SIL Kit FMU Importer with the Modelica Reference FMUs (0.0.23). As these are not our own FMUs, we did not add the examplesUrl field.