### PR TITLE
Add C-code support for some tools

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1063,6 +1063,7 @@
         "platforms": [
             "Linux",
             "Windows"
+            "Source Code"
         ],
         "fmiVersions": [
             "2.0",
@@ -2166,6 +2167,7 @@
             "macOS",
             "Linux",
             "Windows"
+            "Source Code"
         ],
         "fmiVersions": [
             "1.0",
@@ -2220,6 +2222,7 @@
             "macOS",
             "Linux",
             "Windows"
+            "Source Code"
         ],
         "interfaces": [
             "GUI",
@@ -3382,6 +3385,7 @@
         "features": [],
         "platforms": [
             "Windows"
+            "Source Code"
         ],
         "fmiVersions": [
             "1.0",

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1062,7 +1062,7 @@
         "features": [],
         "platforms": [
             "Linux",
-            "Windows"
+            "Windows",
             "Source Code"
         ],
         "fmiVersions": [
@@ -2166,7 +2166,7 @@
         "platforms": [
             "macOS",
             "Linux",
-            "Windows"
+            "Windows",
             "Source Code"
         ],
         "fmiVersions": [
@@ -2221,7 +2221,7 @@
         "platforms": [
             "macOS",
             "Linux",
-            "Windows"
+            "Windows",
             "Source Code"
         ],
         "interfaces": [
@@ -3384,7 +3384,7 @@
         ],
         "features": [],
         "platforms": [
-            "Windows"
+            "Windows",
             "Source Code"
         ],
         "fmiVersions": [


### PR DESCRIPTION
Sources: 

- https://github.com/modelica/fmi-cross-check/tree/master/fmus/2.0/cs/c-code 
- https://de.mathworks.com/help/slcompiler/gs/export-model-to-standalone-fmu-with-source-code.html