### PR TITLE
Update for VenetDCP info

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -3883,13 +3883,16 @@
         "description": "VenetDCP is a distributed co-simulation platform  which enables to connect various models and tools over the internet and compose a cyberspace for integrated simulation test",
         "features": [],
         "platforms": [
-            "Windows"
+            "Windows",
+            "Linux"
         ],
         "fmiVersions": [
-            "2.0"
+            "2.0",
+            "3.0"
         ],
         "fmuExport": [
-            "CS"
+            "CS",
+            "ME"
         ],
         "fmuImport": []
     },


### PR DESCRIPTION
VenetDCP V3.4 released in January 2024.
Please check back for updated information on VenetDCP.