### PR TITLE
Update Silver capatibities in tools page

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -3133,8 +3133,7 @@
             "3.0"
         ],
         "fmuExport": [
-            "CS",
-            "ME"
+            "CS"
         ],
         "fmuImport": [
             "CS",


### PR DESCRIPTION
Synopsys Silver used to export FMI 1.0 ME. We deprecated this feature and will be removed in next Silver release. Therefore we update the Silver capabilities here.