### PR TITLE
[FIX] - remove space in url for districtlab

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -5,7 +5,7 @@
         "url": "https://www.districtlab.eu/our-solution/",
         "logo": "IconDLab.png",
         "vendor": "DistrictLab",
-        "vendorURL": "https: //www.districtlab.eu/",
+        "vendorURL": "https://www.districtlab.eu/",
         "description": "The SimulationStudio is a graphical modelling environment for district heating and cooling simulation and Model-Based Design.",
         "features": [],
         "platforms": [


### PR DESCRIPTION
Hello FMI Team,
I did not see that there were a trailing space in the vendorURL of DistrictLab. Thanks for your reactivity.
Kind regards,
DistrictLab Team 