### PR TITLE
Update tools.json for CarSim

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -764,11 +764,13 @@
         "description": "CarSim, TruckSim, and BikeSim are vehicle dynamics software solutions from Mechanical Simulation that support XiL development workflows and power real-time driving simulators around the globe",
         "features": [],
         "platforms": [
-            "Windows"
+            "Windows",
+            "Linux"
         ],
         "fmiVersions": [
             "1.0",
-            "2.0"
+            "2.0",
+            "3.0"
         ],
         "fmuExport": [
             "CS"


### PR DESCRIPTION
Starting CarSim2023.2, released on Sep/2023, FMU3.0 is supported on both Linux and Windows.