### PR TITLE
Add FMIExchange.jl to tools

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1797,7 +1797,7 @@
 	"url": "https://github.com/Electa-Git/FMIExchange.jl",
 	"vendor": "@CasBex",
 	"vendorURL": "https://github.com/CasBex",
-	"examplesURL": "https://electa-git.github.io/FMIExchange.jl/dev/tutorial/",
+	"examplesURL": "https://electa-git.github.io/FMIExchange.jl/dev/",
 	"description": "Compatibility layer between the FMI standard and the DifferentialEquations.jl Julia package. Compose simulations with multiple FMUs and native models.",
 	"features": [],
 	"platforms": [

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1792,6 +1792,30 @@
         ]
     },
     {
+	"name": "FMIExchange.jl",
+	"license": "osi",
+	"url": "https://github.com/Electa-Git/FMIExchange.jl",
+	"vendor": "@CasBex",
+	"vendorURL": "https://github.com/CasBex",
+	"examplesURL": "https://electa-git.github.io/FMIExchange.jl/dev/tutorial/",
+	"description": "Compatibility layer between the FMI standard and the DifferentialEquations.jl Julia package. Compose simulations with multiple FMUs and native models.",
+	"features": [],
+	"platforms": [
+	    "Linux",
+	    "Windows"
+	],
+	"interfaces": [
+	    "library"
+	],
+	"fmiVersions": [
+	    "2.0"
+	],
+	"fmuExport": [],
+	"fmuImport": [
+	    "ME"
+	]
+    },
+    {
         "name": "FMI4cpp",
         "license": "osi",
         "url": "https://github.com/NTNU-IHB/fmi4cpp",


### PR DESCRIPTION
Add [FMIExchange.jl](https://github.com/Electa-Git/FMIExchange.jl) to the tools list. See also https://github.com/Electa-Git/FMIExchange.jl/issues/4 .