### PR TITLE
Update tools.json: Synopsys removes support for FMUSDK

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1913,31 +1913,6 @@
         ]
     },
     {
-        "name": "FMU SDK",
-        "license": "osi",
-        "url": "https://www.synopsys.com/verification/virtual-prototyping/virtual-ecu/fmu-sdk.html",
-        "logo": "Synopsys.svg",
-        "vendor": "Synopsys",
-        "vendorURL": "https://www.synopsys.com/",
-        "description": "FMU Software Development Kit from Synopsys",
-        "features": [],
-        "platforms": [
-            "Windows"
-        ],
-        "fmiVersions": [
-            "1.0",
-            "2.0"
-        ],
-        "fmuExport": [
-            "CS",
-            "ME"
-        ],
-        "fmuImport": [
-            "CS",
-            "ME"
-        ]
-    },
-    {
         "name": "GCAir",
         "license": "commercial",
         "url": "http://www.globalcrown.com.cn/",


### PR DESCRIPTION
FMUSDK is no longer available on Synopsys web site. I remove FMUSDK from fmi tools list too.