### PR TITLE
Add OpenTwins to tools.json and logo upload

### DIFF
--- a/static/assets/images/logos/opentwins.svg
+++ b/static/assets/images/logos/opentwins.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="202.39275mm"
+   height="233.9431mm"
+   version="1.1"
+   viewBox="0 0 202.39275 233.9431"
+   id="svg43"
+   sodipodi:docname="result.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview45"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false" />
+  <defs
+     id="defs15">
+    <clipPath
+       id="c">
+      <path
+         d="m -26.331,25.787 14.486,8.3662 185.33,-0.72598 14.029,-8.0913 v 146.02 l -148.94,62.167 -88.03,-90.89 8.2713,-114.3 z"
+         display="none"
+         stroke="#f20606"
+         stroke-width="0.27836"
+         id="path2" />
+      <path
+         class="powerclip"
+         d="m -31.329,-40.712 h 223.05 v 256 h -223.05 z m 4.9985,66.499 -14.847,2.5458 -8.2713,114.3 88.03,90.89 148.94,-62.167 v -146.02 l -14.029,8.0913 -185.33,0.72598 z"
+         stroke="#f20606"
+         stroke-width="0.27836"
+         id="path4" />
+    </clipPath>
+    <clipPath
+       id="b">
+      <path
+         d="m -26.331,25.787 14.486,8.3662 185.33,-0.72598 14.029,-8.0913 v 146.02 l -148.94,62.167 -88.03,-90.89 8.2713,-114.3 z"
+         stroke="#f20606"
+         stroke-width="0.27836"
+         id="path7" />
+    </clipPath>
+    <clipPath
+       id="a">
+      <path
+         d="m 189.09,33.534 -98.759,57.01 v 119.22 l 110.61,-57.661 z"
+         display="none"
+         fill="#e2f206"
+         stroke-width="0"
+         id="path10" />
+      <path
+         class="powerclip"
+         d="m -33.701,13.596 h 227.79 v 204.43 h -227.79 z m 222.79,19.938 -98.759,57.01 v 119.22 l 110.61,-57.661 z"
+         fill="#e2f206"
+         stroke-width="0"
+         id="path12" />
+    </clipPath>
+  </defs>
+  <g
+     fill="none"
+     stroke-width="13.229"
+     id="g21"
+     transform="translate(-4.1890249,-11.125366)">
+    <path
+       transform="matrix(0.95,0,0,0.95099,29.203,45.085)"
+       d="m 180.1,144.97 -99.908,57.682 -99.908,-57.682 1e-6,-115.36 99.908,-57.682 L 180.1,29.61 Z"
+       clip-path="url(#b)"
+       stroke="#40407a"
+       id="path17" />
+    <path
+       transform="matrix(0.95,0,0,0.95099,29.203,45.085)"
+       d="m 180.1,144.97 -99.908,57.682 -99.908,-57.682 1e-6,-115.36 99.908,-57.682 L 180.1,29.61 Z"
+       clip-path="url(#c)"
+       stroke="#33d9b2"
+       id="path19" />
+  </g>
+  <g
+     display="none"
+     fill="none"
+     stroke="#f20606"
+     id="g27"
+     transform="translate(-4.1890249,-11.125366)">
+    <path
+       transform="matrix(0.82478,0,0,0.8257,39.245,56.033)"
+       d="m 180.1,144.97 -99.908,57.682 -99.908,-57.682 1e-6,-115.36 99.908,-57.682 L 180.1,29.61 Z"
+       stroke-width="15.105"
+       id="path23" />
+    <rect
+       transform="scale(-1,1)"
+       x="-105.39"
+       y="1.9776"
+       width="1.2692e-05"
+       height="256.64999"
+       stroke-width="0.00021761"
+       id="rect25" />
+  </g>
+  <path
+     transform="matrix(0.69895,0.0036248,0,0.70276,45.069975,55.347634)"
+     d="m -18.624,28.978 -1.0913,0.62993 v 115.36 l 99.909,57.682 99.908,-57.682 v -115.36 l -1.0994,-0.63481 -98.817,57.052 z"
+     clip-path="url(#a)"
+     fill="none"
+     stroke="#33d9b2"
+     stroke-width="17.973"
+     id="path29" />
+  <path
+     d="M 101.13098,108.82463 7.6559751,54.051634 l -7.65270003,4.4358 0.011843,5.7141 L 101.13512,123.40953 Z"
+     display="none"
+     fill="#40407a"
+     stroke-width="0"
+     id="path31" />
+  <rect
+     transform="scale(-1,1)"
+     x="-101.20097"
+     y="-9.1477661"
+     width="1.2692e-05"
+     height="256.64999"
+     fill="none"
+     stroke="#f20606"
+     stroke-width="0.00021761"
+     id="rect33" />
+  <rect
+     transform="matrix(0.86707273,-0.49818157,0,1,0,0)"
+     x="116.97839"
+     y="176.26781"
+     width="7.8755751"
+     height="87.577003"
+     rx="0"
+     ry="31.195"
+     fill="#33d9b2"
+     stroke-width="0"
+     id="rect35" />
+  <rect
+     transform="matrix(-0.86707273,-0.49818157,0,1,0,0)"
+     x="-117.56839"
+     y="51.247463"
+     width="7.8755751"
+     height="87.577003"
+     rx="0"
+     ry="31.195"
+     fill="#33d9b2"
+     stroke-width="0"
+     id="rect37" />
+  <rect
+     transform="matrix(0.87526114,-0.48365063,0,1,0,0)"
+     x="151.54376"
+     y="168.55988"
+     width="14.427981"
+     height="92.009003"
+     rx="0"
+     ry="7.2140999"
+     fill="#33d9b2"
+     stroke-width="0"
+     id="rect39" />
+  <path
+     d="m 25.009975,72.404634 7.0328,-4.0462 -24.3869999,-14.31 -7.65270003,4.4358 0.011843,5.7141 24.99299993,14.635 z"
+     fill="#40407a"
+     stroke-width="0"
+     id="path41" />
+</svg>

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -4748,5 +4748,32 @@
             "CS"
         ],
         "fmuImport": []
+    },
+    {
+        "name": "OpenTwins",
+        "license": "osi",
+        "url": "https://github.com/ertis-research/opentwins",
+        "logo": "opentwins.svg",
+        "vendor": "ERTIS Research | University of Málaga",
+        "vendorURL": "https://ertis.uma.es/",
+        "description": "OpenTwins is a platform designed to facilitate the development of digital twins and is characterised by the exclusive use of open source components. The aim is to achieve a platform that covers all the functionalities that a digital twin may require, from the most basic ones, such as simply checking its real-time state, to more advanced ones, such as the inclusion of predicted or simulated data. Simulations are compatible with FMI standard.",
+        "features": [],
+        "platforms": [
+            "macOS",
+            "Linux",
+            "Windows"
+        ],
+        "interfaces": [
+            "GUI",
+            "CLI"
+        ],
+        "fmiVersions": [
+            "2.0"
+        ],
+        "fmuExport": [
+        ],
+        "fmuImport": [
+            "CS"
+        ]
     }
 ]


### PR DESCRIPTION
Following suggestion in:
https://github.com/ertis-research/opentwins/issues/11

We are adding OpenTwins as FMI compatible tool.