### PR TITLE
GT-SUITE updates

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1988,11 +1988,13 @@
         "description": "Multi-Physics Simulation Platform for Powertrain and Vehicle Systems",
         "features": [],
         "platforms": [
-            "Windows"
+            "Windows",
+		"Linux"
         ],
         "fmiVersions": [
             "1.0",
-            "2.0"
+            "2.0",
+		"3.0"
         ],
         "fmuExport": [
             "CS"


### PR DESCRIPTION
Add FMI 3.0 tag to the supported fmiVersions for GT-SUITE.

Since GT-2024.0 FMI 3.0 is supported for FMUExport Since GT-2025.0 FMI 3.0 will be supported for FMUImport

FMI 1.0, 2.0 and 3.0 are supported for Linux as well. Adding Linux tag too.

By Pantelis Dimitrakopoulos from GT