### PR TITLE
Tools-list; fmi-library, added fmi 3.0 support

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1708,7 +1708,7 @@
         "fmiVersions": [
             "1.0",
             "2.0",
-	    "3.0"
+			"3.0"
         ],
         "fmuExport": [],
         "fmuImport": [

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1708,7 +1708,7 @@
         "fmiVersions": [
             "1.0",
             "2.0",
-			"3.0"
+            "3.0"
         ],
         "fmuExport": [],
         "fmuImport": [

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1707,7 +1707,8 @@
         ],
         "fmiVersions": [
             "1.0",
-            "2.0"
+            "2.0",
+	    "3.0"
         ],
         "fmuExport": [],
         "fmuImport": [


### PR DESCRIPTION
Updating the tools list to reflect that fmi-library supports fmi 3.0