### PR TITLE
Update Vector CANape URL

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -4743,7 +4743,7 @@
     {
         "name": "CANape",
         "license": "commercial",
-        "url": "https://www.vector.com/int/en/products/products-a-z/software/canape/",
+        "url": "https://www.vector.com/int/en/products/products-a-z/software/canape/canape-application-areas/#c339072",
         "logo": "Vector.svg",
         "vendor": "Vector",
         "vendorURL": "https://vector.com/",


### PR DESCRIPTION
This commit updates the URL of Vector CANape to link to an improved website.