### PR TITLE
Add examples URL for Hopsan tool

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -2080,6 +2080,7 @@
         "logo": "hopsan-logo.svg",
         "vendor": "Link\u00f6ping University",
         "vendorURL": "https://liu.se/en/research/hopsan",
+        "examplesURL": "https://hopsan.github.io/documentation/fmi.html",
         "description": "A system simulation tool based on distributed solvers, focused mostly on fluid and mechatronic systems.",
         "features": [],
         "platforms": [


### PR DESCRIPTION
Added URL to compatibility information and example FMUs (separate link from this page).