### PR TITLE
Remove examplesURL from "fmi_adapter for ROS"

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -4570,7 +4570,6 @@
         "logo": "Bosch.svg",
         "vendor": "Bosch Research",
         "vendorURL": "https://www.bosch.com/research/",
-        "examplesURL": "https://index.ros.org/p/fmi_adapter_examples/",
         "description": "ROS package for wrapping FMUs into ROS nodes, supporting node-based and library-based usage",
         "features": [],
         "platforms": [


### PR DESCRIPTION
as the linked website does not provide the required compatibility information and all provided FMUs have invalid model descriptions.