### PR TITLE
Add fmi4c to tools list

### DIFF
--- a/static/assets/images/logos/fmi4c.svg
+++ b/static/assets/images/logos/fmi4c.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg4705"
+   width="198.24879"
+   height="54.481667"
+   viewBox="0 0 198.2488 54.481667"
+   sodipodi:docname="fmi4c.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata4711">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4709" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1680"
+     inkscape:window-height="979"
+     id="namedview4707"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="1.6879449"
+     inkscape:cx="23.697456"
+     inkscape:cy="79.09026"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4705"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <rect
+     style="fill:#6e1b1b;fill-opacity:1;stroke:#6e1b1b;stroke-width:0.666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect4-0-1-4-3"
+     width="197.58017"
+     height="4.9708452"
+     x="0.33528903"
+     y="49.177486" />
+  <path
+     style="font-size:97.3333px;font-family:Verdana;-inkscape-font-specification:Verdana;fill:#000000;stroke:#000000;stroke-width:0.666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 107.35585,44.214583 H 88.148655 V 39.7351 h 6.36974 V 4.8128162 h -6.36974 V 0.33333349 H 107.35585 V 4.8128162 h -6.36973 V 39.7351 h 6.36973 z"
+     id="path8" />
+  <path
+     style="font-size:97.3333px;font-family:Verdana;-inkscape-font-specification:Verdana;fill:#000000;stroke:#000000;stroke-width:0.666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="m 81.430448,44.214583 h -6.46773 V 6.4042112 L 61.439277,32.131767 H 57.584771 L 44.159332,6.4042112 V 44.214583 H 38.116246 V 0.33333349 h 8.819636 L 59.90401,24.764196 72.447485,0.33333349 h 8.982963 z"
+     id="path7" />
+  <path
+     style="font-size:97.3333px;font-family:Verdana;-inkscape-font-specification:Verdana;fill:#000000;stroke:#000000;stroke-width:0.666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 31.398045,5.5201032 H 6.8010631 V 17.897621 H 27.935521 V 23.08439 H 6.8010631 V 44.214583 H 0.33333349 V 0.33333349 H 31.398045 Z"
+     id="path4" />
+  <path
+     style="font-size:97.3333px;font-family:Verdana;-inkscape-font-specification:Verdana;fill:#6e1b1b;fill-opacity:1;stroke:#6e1b1b;stroke-width:0.666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="m 150.85519,35.199791 h -7.21903 v 13.653315 h -6.27174 V 35.199791 h -23.29036 v -7.49466 L 137.62574,0.33333349 h 6.01042 V 29.986115 h 7.21903 z M 137.36442,29.986115 V 8.0886752 L 118.51654,29.986115 Z"
+     id="path5" />
+  <path
+     style="font-size:97.3333px;font-family:Verdana;-inkscape-font-specification:Verdana;fill:#000000;stroke:#000000;stroke-width:0.666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="m 197.91505,41.17816 q -1.79659,0.696219 -3.26653,1.30541 -1.43727,0.609192 -3.78917,1.276401 -1.99259,0.551174 -4.34449,0.928292 -2.31924,0.406128 -5.12845,0.406128 -5.29178,0 -9.63627,-1.305411 -4.31182,-1.334419 -7.51302,-4.148302 -3.13587,-2.755866 -4.8998,-6.991196 -1.76393,-4.264339 -1.76393,-9.892106 0,-5.337677 1.6986,-9.543998 1.6986,-4.2063208 4.8998,-7.1072318 3.1032,-2.8138832 7.48036,-4.2933483 4.40981,-1.47946441 9.76692,-1.47946441 3.91984,0 7.80701,0.84126431 3.91984,0.8412638 8.68897,2.958929 v 6.8171402 h -0.48998 q -4.01783,-2.9879378 -7.97033,-4.3513658 -3.9525,-1.363428 -8.46032,-1.363428 -3.69118,0 -6.66372,1.073337 -2.93988,1.044328 -5.25912,3.27803 -2.2539,2.1756828 -3.52785,5.5117298 -1.24128,3.307039 -1.24128,7.658406 0,4.55443 1.37195,7.832459 1.4046,3.27803 3.59318,5.337677 2.28657,2.146673 5.32444,3.191002 3.07054,1.015318 6.46773,1.015318 4.67114,0 8.75431,-1.421446 4.08316,-1.421447 7.64368,-4.264339 h 0.45731 z"
+     id="path6" />
+</svg>

--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -5177,5 +5177,30 @@
             "CS",
             "ME"
         ]
+    },
+    {
+        "name": "fmi4c",
+        "license": "osi",
+        "url": "https://github.com/robbr48/fmi4c",
+        "logo": "fmi4c.svg",
+        "vendor": "Link\u00f6ping University",
+        "vendorURL": "https://liu.se/en/organisation/liu/iei/flumes",
+        "description": "An open-source C library that facilitates integrating FMI import in applications and tools",
+        "features": [],
+        "platforms": [
+            "Linux",
+            "Windows"
+        ],
+        "fmiVersions": [
+            "1.0",
+            "2.0",
+            "3.0"
+        ],
+        "fmuExport": [],
+        "fmuImport": [
+            "CS",
+            "ME",
+            "SE"
+        ]
     }
 ]


### PR DESCRIPTION
Since fmi4c is a library, the compatibility cannot be directly validated. It is, however, used as a backend by the Hopsan simulation tool which does provide compatibility information. I am not sure if this information can be reused here?