### PR TITLE
Update tools.json for STC

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -5264,11 +5264,11 @@
     {
         "name": "Simulation Trust Center",
         "license": "commercial",
-        "url": "https://stc.dnv.com",
+        "url": "https://store.veracity.com/simulation-trust-center",
         "logo": "DNV_logo_RGB.png",
         "vendor": "DNV",
         "vendorURL": "https://www.dnv.com/",
-        "examplesURL": "https://stc.dnv.com/public",
+        "examplesURL": "https://github.com/open-simulation-platform/demo-cases",
         "description": "Simulation Trust Center is a collaborative simulation tool that allows secure upload, storage, sharing, and execution of FMUs in a cloud-hosted co-simulation environment.",
         "features": [],
         "platforms": [


### PR DESCRIPTION
Replace the urls for STC with publicly accessible URLs.

Addressing the concerns brought up in https://github.com/modelica/fmi-standard.org/pull/691 and over e-mail.

Just let me know if this suffices!
