### PR TITLE
fix gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
           pattern: "\\.json$"
       - uses: actions/configure-pages@v1
       - uses: jakejarvis/hugo-build-action@v0.101.0
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: public
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
           pattern: "\\.json$"
       - uses: actions/configure-pages@v1
       - uses: jakejarvis/hugo-build-action@v0.101.0
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: public
 


### PR DESCRIPTION
Fixing the error 
"Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/"


https://github.com/modelica/fmi-ls-bus/pull/235/files