### PR TITLE
Add dSPACE MicroLabBox II to tools list

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -1178,7 +1178,7 @@
         "logo": "dSPACE.png",
         "vendor": "dSPACE",
         "vendorURL": "https://www.dspace.com/go/fmi",
-        "description": "ConfigurationDesk is an intuitive, graphical configuration and implementation tool, ideal for handling applications from small Rapid Control Prototyping (RCP) developments to large Hardware-in-the-Loop (HIL) tests based on dSPACE real-time hardware, such as SCALEXIO or MicroAutoBox III, including the implementation of behavior models and I/O function code.",
+        "description": "ConfigurationDesk is an intuitive, graphical configuration and implementation tool, ideal for handling applications from small Rapid Control Prototyping (RCP) developments to large Hardware-in-the-Loop (HIL) tests based on dSPACE real-time hardware, such as SCALEXIO, MicroLabBox II or MicroAutoBox III, including the implementation of behavior models and I/O function code.",
         "features": [],
         "platforms": [
             "Linux"
@@ -1200,6 +1200,28 @@
         "vendor": "dSPACE",
         "vendorURL": "https://www.dspace.com/go/fmi",
         "description": "MicroAutoBox III is a real-time simulation system for performing fast, in-vehicle function prototyping. Simulations for MicroAutoBox III are implemented with ConfigurationDesk.",
+        "features": [],
+        "platforms": [
+            "Linux",
+            "Source Code"
+        ],
+        "fmiVersions": [
+            "2.0",
+            "3.0"
+        ],
+        "fmuExport": [],
+        "fmuImport": [
+            "CS"
+        ]
+    },
+    {
+        "name": "MicroLabBox II",
+        "license": "commercial",
+        "url": " https://www.dspace.com/go/microlabbox",
+        "logo": "dSPACE.png",
+        "vendor": "dSPACE",
+        "vendorURL": "https://www.dspace.com/go/fmi",
+        "description": "MicroLabBox II is a compact and powerful development and test system for rapid control prototyping and hardware-in-the-loop applications. Simulations for MicroLabBox II are implemented with ConfigurationDesk.",
         "features": [],
         "platforms": [
             "Linux",


### PR DESCRIPTION
I would like to add the dSPACE MicroLabBox II to the FMI tools list. 