### PR TITLE
Update MathWorks entries in the tools list

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -2657,7 +2657,8 @@
             "3.0"
         ],
         "fmuExport": [
-            "CS"
+            "CS",
+			"ME"
         ],
         "fmuImport": [
             "CS",
@@ -2683,7 +2684,8 @@
         ],
         "fmiVersions": [
             "1.0",
-            "2.0"
+            "2.0",
+			"3.0"
         ],
         "fmuImport": [
             "CS"


### PR DESCRIPTION
The MathWorks entries in the tools list are outdated and require updates. This pull request is to:
a. Add Model Exchange FMU export support for MATLAB/Simulink.
b. Add FMI 3 FMU import for Simulink Real-Time.

Thank you.