### PR TITLE
Update Scilab tool info

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -3493,7 +3493,7 @@
     },
     {
         "name": "Scilab/Xcos FMU wrapper",
-        "license": "CeCILL",
+        "license": "osi",
         "url": "https://atoms.scilab.org/toolboxes/fmu_wrapper/3.0.0/",
         "vendor": "Dassault Syst\u00e8mes",
         "vendorURL": "https://3ds.com/",


### PR DESCRIPTION
Scilab now handles FMI 1.0,2.0 and 3.0 with the fmu_wrapper Atoms package