### PR TITLE
Update PathSim URL in tools.json

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -6292,7 +6292,7 @@
     {
         "name": "PathSim",
         "license": "osi",
-        "url": "https://github.com/milanofthe/pathsim",
+        "url": "https://github.com/pathsim/pathsim",
         "logo": "pathsim.png",
         "vendor": "Milan Rother",
         "vendorURL": "https://pathsim.readthedocs.io/en/latest",


### PR DESCRIPTION
PathSim is now owned by the GitHub org pathsim https://github.com/pathsim