### PR TITLE
Update HyperLynx AMS entry in tools.json

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -3737,12 +3737,10 @@
         "description": "Hyperlynx AMS is an analog/mixed-signal circuit simulation tool that is integrated with the printed circuit board (PCB) schematic capture tool Xpedition Designer. HL-AMS can create and generate component models, perform time- and frequency-domain analyses, and provide detailed visualization and analysis of results. Compatible model types include SPICE, VHDL-AMS, Verilog-AMS, S Parameter, and IBIS.",
         "features": [],
         "platforms": [
-            "Linux",
-            "Windows"
+            "Linux"
         ],
         "interfaces": [
-            "GUI",
-            "CLI"
+            "GUI"
         ],
         "fmiVersions": [
             "2.0"


### PR DESCRIPTION
Clarified details in the HyperLynx AMS entry - while the Xpedition Designer tool is CLI and Linux compatible, the HL AMS feature is not.