### PR TITLE
Update tools.json - PLECS 5.0 supports FMI 3.0 and CS

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -3327,13 +3327,16 @@
             "Windows"
         ],
         "fmiVersions": [
-            "2.0"
+            "2.0",
+			"3.0"
         ],
         "fmuExport": [
-            "ME"
+            "ME",
+			"CS"
         ],
         "fmuImport": [
-            "ME"
+            "ME",
+			"CS"
         ]
     },
     {


### PR DESCRIPTION
As of now PLECS 5.0 also supports FMI Version 3.0 and Co-Simulation FMUs for import and export.