### PR TITLE
Updating tools page; FMI3.0 ME export for Modelon Impact + GUI/CLI

### DIFF
--- a/static/assets/tools.json
+++ b/static/assets/tools.json
@@ -3035,8 +3035,13 @@
             "Windows",
             "Source Code"
         ],
+        "interfaces": [
+            "GUI",
+            "CLI"
+        ],
         "fmiVersions": [
-            "2.0"
+            "2.0",
+            "3.0"
         ],
         "fmuExport": [
             "CS",


### PR DESCRIPTION
We recently added support for FMI3.0 ModelExchange export.

Disclaimer: We don't have FMI3.0 CS export or import yet, but the current reporting doesn't allow this distinction.